### PR TITLE
Fix language switcher spec imports

### DIFF
--- a/src/app/components/languague-switcher/languague-switcher.component.spec.ts
+++ b/src/app/components/languague-switcher/languague-switcher.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { LanguagueSwitcherComponent } from './languague-switcher.component';
+import { LanguageSwitcherComponent } from './languague-switcher.component';
 
-describe('LanguagueSwitcherComponent', () => {
-  let component: LanguagueSwitcherComponent;
-  let fixture: ComponentFixture<LanguagueSwitcherComponent>;
+describe('LanguageSwitcherComponent', () => {
+  let component: LanguageSwitcherComponent;
+  let fixture: ComponentFixture<LanguageSwitcherComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LanguagueSwitcherComponent]
+      imports: [LanguageSwitcherComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(LanguagueSwitcherComponent);
+    fixture = TestBed.createComponent(LanguageSwitcherComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });


### PR DESCRIPTION
## Summary
- update the language switcher component spec to import the correctly named component class
- align the test descriptions and types with the exported `LanguageSwitcherComponent`

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e13c8c7e7c83238cd7944b4442029d