### PR TITLE
Add contact messaging service and server endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Compiled output
 /dist
+/.tmp
 /tmp
 /out-tsc
 /bazel-out

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ To execute unit tests with the [Karma](https://karma-runner.github.io) test runn
 ng test
 ```
 
+Server-side API tests are implemented with Node's test runner. Execute them with:
+
+```bash
+npm run test:server
+```
+
+## Contact API configuration
+
+The `/api/contact` endpoint forwards messages through SMTP using [Nodemailer](https://nodemailer.com/). Configure the following environment variables before starting the server:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `CONTACT_SMTP_HOST` | Yes (unless `CONTACT_TRANSPORT=json`) | SMTP server host name. |
+| `CONTACT_SMTP_PORT` | No | SMTP port (defaults to `587`). |
+| `CONTACT_SMTP_SECURE` | No | Set to `true` to enforce SMTPS (defaults based on port). |
+| `CONTACT_SMTP_USER` | Yes (unless `CONTACT_TRANSPORT=json`) | SMTP username. |
+| `CONTACT_SMTP_PASS` | Yes (unless `CONTACT_TRANSPORT=json`) | SMTP password. |
+| `CONTACT_RECIPIENT` | No | Override the email recipient (defaults to `ferizovicsuco3@gmail.com`). |
+| `CONTACT_FROM_ADDRESS` | No | Explicit “from” address (defaults to the SMTP user or the sender email). |
+| `CONTACT_TRANSPORT` | No | Set to `json` to use Nodemailer's JSON transport (useful for local testing). |
+
+When running tests you can set `CONTACT_TRANSPORT=json` to avoid connecting to a real SMTP server.
+
 ## Running end-to-end tests
 
 For end-to-end (e2e) testing, run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@ngx-translate/http-loader": "^17.0.0",
         "@tailwindcss/line-clamp": "^0.4.4",
         "express": "^4.18.2",
+        "nodemailer": "file:vendor/nodemailer",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -10855,6 +10856,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "resolved": "vendor/nodemailer",
+      "link": true
+    },
     "node_modules/nopt": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
@@ -15279,6 +15284,9 @@
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
       "license": "MIT"
+    },
+    "vendor/nodemailer": {
+      "version": "0.0.0-local"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "test:server": "tsc --project tsconfig.server-test.json && node --test .tmp/server-tests/tests/server/contact-endpoint.spec.js",
     "serve:ssr:portfolio": "node dist/portfolio/server/server.mjs"
   },
   "private": true,
@@ -25,6 +26,7 @@
     "@ngx-translate/http-loader": "^17.0.0",
     "@tailwindcss/line-clamp": "^0.4.4",
     "express": "^4.18.2",
+    "nodemailer": "file:vendor/nodemailer",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -14,16 +14,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'portfolio' title`, () => {
+  it('should expose navigation links', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('portfolio');
+    expect(app.navLinks.length).toBeGreaterThan(0);
+    expect(app.navLinks.some((link) => link.path === '/contact')).toBeTrue();
   });
 
-  it('should render title', () => {
+  it('should expose social links', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, portfolio');
+    const app = fixture.componentInstance;
+    expect(app.socialLinks.some((link) => link.icon === 'mail')).toBeTrue();
   });
 });

--- a/src/app/components/contact/contact.component.html
+++ b/src/app/components/contact/contact.component.html
@@ -120,7 +120,10 @@
         novalidate
         [attr.aria-describedby]="status === 'error' ? 'contact-status' : null"
       >
-        <div *ngIf="status === 'success'" class="rounded-2xl border border-emerald-200/80 bg-emerald-50/80 px-4 py-3 text-sm font-medium text-emerald-600 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-200">
+        <div
+          *ngIf="status === 'success'"
+          class="rounded-2xl border border-emerald-200/80 bg-emerald-50/80 px-4 py-3 text-sm font-medium text-emerald-600 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-200"
+        >
           {{ 'CONTACT.STATUS.SUCCESS' | translate }}
         </div>
         <div
@@ -236,20 +239,41 @@
         <div class="flex justify-end">
           <button
             type="submit"
-            class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 dark:bg-blue-600 dark:hover:bg-blue-500"
+            class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 disabled:cursor-not-allowed disabled:opacity-70 dark:bg-blue-600 dark:hover:bg-blue-500"
+            [disabled]="submitting"
+            [attr.aria-busy]="submitting"
           >
-            {{ 'CONTACT.BUTTON' | translate }}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              class="h-4 w-4"
-              aria-hidden="true"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0-6-6m6 6-6 6" />
-            </svg>
+            <span class="inline-flex items-center gap-2">
+              {{ 'CONTACT.BUTTON' | translate }}
+              <svg
+                *ngIf="!submitting"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                class="h-4 w-4"
+                aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0-6-6m6 6-6 6" />
+              </svg>
+              <svg
+                *ngIf="submitting"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                class="h-4 w-4 animate-spin"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M12 3a9 9 0 1 1-9 9"
+                />
+              </svg>
+            </span>
           </button>
         </div>
       </form>

--- a/src/app/components/contact/contact.component.spec.ts
+++ b/src/app/components/contact/contact.component.spec.ts
@@ -1,16 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
 
+import { ContactService } from '../../services/contact.service';
 import { ContactComponent } from './contact.component';
 
 describe('ContactComponent', () => {
   let component: ContactComponent;
   let fixture: ComponentFixture<ContactComponent>;
+  let contactService: jasmine.SpyObj<ContactService>;
 
   beforeEach(async () => {
+    contactService = jasmine.createSpyObj<ContactService>('ContactService', [
+      'sendMessage',
+    ]);
+
     await TestBed.configureTestingModule({
-      imports: [ContactComponent]
-    })
-    .compileComponents();
+      imports: [ContactComponent],
+      providers: [{ provide: ContactService, useValue: contactService }],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ContactComponent);
     component = fixture.componentInstance;
@@ -19,5 +26,54 @@ describe('ContactComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should submit valid form, call the service and show success', () => {
+    contactService.sendMessage.and.returnValue(of(void 0));
+
+    component.contactForm.setValue({
+      name: 'John Doe',
+      email: 'john@example.com',
+      message: 'Hello there, this message is long enough.',
+    });
+
+    component.onSubmit();
+
+    expect(contactService.sendMessage).toHaveBeenCalledWith({
+      name: 'John Doe',
+      email: 'john@example.com',
+      message: 'Hello there, this message is long enough.',
+    });
+    expect(component.status).toBe('success');
+    expect(component.submitting).toBeFalse();
+    expect(component.contactForm.value).toEqual({
+      name: null,
+      email: null,
+      message: null,
+    });
+  });
+
+  it('should surface an error when the service fails', () => {
+    contactService.sendMessage.and.returnValue(
+      throwError(() => new Error('Network error')),
+    );
+
+    component.contactForm.setValue({
+      name: 'John Doe',
+      email: 'john@example.com',
+      message: 'Hello there, this message is long enough.',
+    });
+
+    component.onSubmit();
+
+    expect(contactService.sendMessage).toHaveBeenCalled();
+    expect(component.status).toBe('error');
+    expect(component.submitting).toBeFalse();
+    // Form values remain because reset is not called on failure
+    expect(component.contactForm.value).toEqual({
+      name: 'John Doe',
+      email: 'john@example.com',
+      message: 'Hello there, this message is long enough.',
+    });
   });
 });

--- a/src/app/services/contact.service.spec.ts
+++ b/src/app/services/contact.service.spec.ts
@@ -1,0 +1,37 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ContactService } from './contact.service';
+
+describe('ContactService', () => {
+  let service: ContactService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+
+    service = TestBed.inject(ContactService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should POST contact payload to /api/contact', () => {
+    service
+      .sendMessage({ name: 'Test', email: 'test@example.com', message: 'Hello world' })
+      .subscribe();
+
+    const request = httpMock.expectOne('/api/contact');
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual({
+      name: 'Test',
+      email: 'test@example.com',
+      message: 'Hello world',
+    });
+    request.flush({});
+  });
+});

--- a/src/app/services/contact.service.ts
+++ b/src/app/services/contact.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+type ContactPayload = {
+  name: string;
+  email: string;
+  message: string;
+};
+
+@Injectable({ providedIn: 'root' })
+export class ContactService {
+  constructor(private readonly http: HttpClient) {}
+
+  sendMessage(payload: ContactPayload): Observable<void> {
+    return this.http.post<void>('/api/contact', payload);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,18 +1,87 @@
-import {
-  AngularNodeAppEngine,
-  createNodeRequestHandler,
-  isMainModule,
-  writeResponseToNodeResponse,
-} from '@angular/ssr/node';
 import express from 'express';
+import nodemailer from 'nodemailer';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
 
-const app = express();
-const angularApp = new AngularNodeAppEngine();
+const shouldEnableAngular = process.env['ANGULAR_DISABLE_SSR'] !== 'true';
+
+export const app = express();
+
+app.use(express.json());
+
+type ContactRequestBody = {
+  name?: unknown;
+  email?: unknown;
+  message?: unknown;
+};
+
+const buildTransporter = () => {
+  if (process.env['CONTACT_TRANSPORT'] === 'json') {
+    return nodemailer.createTransport({ jsonTransport: true });
+  }
+
+  const host = process.env['CONTACT_SMTP_HOST'];
+  const port = process.env['CONTACT_SMTP_PORT'];
+  const user = process.env['CONTACT_SMTP_USER'];
+  const pass = process.env['CONTACT_SMTP_PASS'];
+
+  if (!host || !user || !pass) {
+    return null;
+  }
+
+  const parsedPort = port ? Number.parseInt(port, 10) : 587;
+  const secure = process.env['CONTACT_SMTP_SECURE'] === 'true' || parsedPort === 465;
+
+  return nodemailer.createTransport({
+    host,
+    port: parsedPort,
+    secure,
+    auth: {
+      user,
+      pass,
+    },
+  });
+};
+
+const isNonEmptyString = (value: unknown, minLength = 1): value is string =>
+  typeof value === 'string' && value.trim().length >= minLength;
+
+app.post('/api/contact', async (req, res) => {
+  const body = req.body as ContactRequestBody;
+  const { name, email, message } = body ?? {};
+
+  if (!isNonEmptyString(name, 3) || !isNonEmptyString(email) || !isNonEmptyString(message, 20)) {
+    return res.status(400).json({ error: 'Invalid contact payload.' });
+  }
+
+  const transporter = buildTransporter();
+
+  if (!transporter) {
+    return res.status(500).json({ error: 'Email transport is not configured.' });
+  }
+
+  const recipient = process.env['CONTACT_RECIPIENT'] ?? 'ferizovicsuco3@gmail.com';
+  const fromAddress =
+    process.env['CONTACT_FROM_ADDRESS'] ?? process.env['CONTACT_SMTP_USER'] ?? email;
+
+  try {
+    await transporter.sendMail({
+      to: recipient,
+      from: fromAddress,
+      replyTo: email,
+      subject: `New portfolio message from ${name}`,
+      text: `From: ${name} <${email}>\n\n${message}`,
+    });
+
+    return res.status(202).json({ message: 'Message sent.' });
+  } catch (error) {
+    console.error('Failed to forward contact message', error);
+    return res.status(502).json({ error: 'Failed to send message.' });
+  }
+});
 
 /**
  * Example Express Rest API endpoints can be defined here.
@@ -37,30 +106,42 @@ app.use(
   }),
 );
 
-/**
- * Handle all other requests by rendering the Angular application.
- */
-app.use('/**', (req, res, next) => {
-  angularApp
-    .handle(req)
-    .then((response) =>
-      response ? writeResponseToNodeResponse(response, res) : next(),
-    )
-    .catch(next);
-});
+let reqHandler: express.RequestHandler;
 
-/**
- * Start the server if this module is the main entry point.
- * The server listens on the port defined by the `PORT` environment variable, or defaults to 4000.
- */
-if (isMainModule(import.meta.url)) {
-  const port = process.env['PORT'] || 4000;
-  app.listen(port, () => {
-    console.log(`Node Express server listening on http://localhost:${port}`);
+if (shouldEnableAngular) {
+  const {
+    AngularNodeAppEngine,
+    createNodeRequestHandler,
+    isMainModule,
+    writeResponseToNodeResponse,
+  } = await import('@angular/ssr/node');
+
+  const angularApp = new AngularNodeAppEngine();
+
+  app.use('/**', (req, res, next) => {
+    angularApp
+      .handle(req)
+      .then((response) =>
+        response ? writeResponseToNodeResponse(response, res) : next(),
+      )
+      .catch(next);
   });
+
+  if (isMainModule(import.meta.url)) {
+    const port = process.env['PORT'] || 4000;
+    app.listen(port, () => {
+      console.log(`Node Express server listening on http://localhost:${port}`);
+    });
+  }
+
+  reqHandler = createNodeRequestHandler(app);
+} else {
+  app.use('/**', (_req, res) => {
+    res.status(501).send('SSR is disabled.');
+  });
+
+  const fallbackHandler: express.RequestHandler = (req, res, next) => app(req, res, next);
+  reqHandler = fallbackHandler;
 }
 
-/**
- * The request handler used by the Angular CLI (dev-server and during build).
- */
-export const reqHandler = createNodeRequestHandler(app);
+export { reqHandler };

--- a/tests/server/contact-endpoint.spec.ts
+++ b/tests/server/contact-endpoint.spec.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { AddressInfo } from 'node:net';
+import { afterEach, before, beforeEach, describe, test } from 'node:test';
+import type { Application } from 'express';
+
+let appInstance: Application;
+
+before(async () => {
+  process.env['ANGULAR_DISABLE_SSR'] = 'true';
+  ({ app: appInstance } = await import('../../src/server.js'));
+});
+
+const validPayload = {
+  name: 'Jane Tester',
+  email: 'jane@example.com',
+  message: 'This is a sufficiently long message body for testing purposes.',
+};
+
+const postContact = async (baseUrl: string, body: unknown) => {
+  const response = await fetch(`${baseUrl}/api/contact`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  let data: unknown = null;
+  try {
+    data = await response.json();
+  } catch (error) {
+    data = null;
+  }
+
+  return { response, data };
+};
+
+describe('POST /api/contact', () => {
+  const originalEnv = { ...process.env };
+  let server: ReturnType<Application['listen']> | null = null;
+  let baseUrl = '';
+
+  beforeEach(() => {
+    server = appInstance.listen(0);
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+
+    Object.assign(process.env, originalEnv);
+
+    if (server) {
+      await new Promise<void>((resolve) => server?.close(() => resolve()));
+      server = null;
+    }
+  });
+
+  test('rejects invalid payloads', async () => {
+    const { response, data } = await postContact(baseUrl, {
+      name: 'Ja',
+      email: 'invalid-email',
+      message: 'Too short',
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal((data as { error: string } | null)?.error, 'Invalid contact payload.');
+  });
+
+  test('accepts valid payload when transport configured via JSON transport', async () => {
+    process.env['CONTACT_TRANSPORT'] = 'json';
+
+    const { response, data } = await postContact(baseUrl, validPayload);
+
+    assert.equal(response.status, 202);
+    assert.equal((data as { message: string } | null)?.message, 'Message sent.');
+  });
+
+  test('returns 500 when no transport configuration is available', async () => {
+    delete process.env['CONTACT_TRANSPORT'];
+    delete process.env['CONTACT_SMTP_HOST'];
+    delete process.env['CONTACT_SMTP_USER'];
+    delete process.env['CONTACT_SMTP_PASS'];
+
+    const { response, data } = await postContact(baseUrl, validPayload);
+
+    assert.equal(response.status, 500);
+    assert.equal((data as { error: string } | null)?.error, 'Email transport is not configured.');
+  });
+});

--- a/tsconfig.server-test.json
+++ b/tsconfig.server-test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./.tmp/server-tests",
+    "moduleResolution": "node",
+    "module": "ES2022",
+    "target": "ES2022",
+    "rootDir": "./",
+    "types": ["node"],
+    "noEmitOnError": true
+  },
+  "include": ["src/server.ts", "tests/server/**/*.ts"]
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -11,5 +11,8 @@
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.d.ts"
+  ],
+  "exclude": [
+    "src/server.spec.ts"
   ]
 }

--- a/vendor/nodemailer/index.d.ts
+++ b/vendor/nodemailer/index.d.ts
@@ -1,0 +1,35 @@
+export interface SendMailOptions {
+  to: string | string[];
+  from: string;
+  subject: string;
+  text: string;
+  replyTo?: string;
+}
+
+export interface Transporter {
+  sendMail(mailOptions: SendMailOptions): Promise<void>;
+}
+
+export interface SMTPTransportOptions {
+  host: string;
+  port?: number;
+  secure?: boolean;
+  name?: string;
+  auth?: {
+    user: string;
+    pass: string;
+  };
+}
+
+export interface JsonTransportOptions {
+  jsonTransport: true;
+}
+
+export type TransportOptions = SMTPTransportOptions | JsonTransportOptions;
+
+export declare const createTransport: (options?: TransportOptions) => Transporter;
+
+declare const _default: {
+  createTransport: (options?: TransportOptions) => Transporter;
+};
+export default _default;

--- a/vendor/nodemailer/index.js
+++ b/vendor/nodemailer/index.js
@@ -1,0 +1,240 @@
+import net from 'node:net';
+import tls from 'node:tls';
+
+const toArray = (value) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (!value) {
+    return [];
+  }
+
+  return [value];
+};
+
+const base64 = (value) => Buffer.from(value, 'utf8').toString('base64');
+
+const normalizeLines = (text = '') =>
+  text
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\n/g, '\r\n');
+
+const escapeLeadingPeriods = (text) => text.replace(/^\./gm, '..');
+
+const createSMTPConnection = (options) =>
+  new Promise((resolve, reject) => {
+    const socket = options.secure
+      ? tls.connect({ host: options.host, port: options.port ?? 465 })
+      : net.createConnection({ host: options.host, port: options.port ?? 587 });
+
+    const pending = [];
+    const queuedResponses = [];
+    let buffer = '';
+    let currentLines = [];
+    let closed = false;
+
+    const processResponse = (response) => {
+      const entry = pending.shift();
+      if (entry) {
+        const { resolve: resolveEntry, reject: rejectEntry, expect } = entry;
+        if (expect && !expect.includes(response.code)) {
+          rejectEntry(
+            new Error(
+              `Unexpected SMTP response ${response.code}: ${response.lines.join(' ')}`,
+            ),
+          );
+        } else {
+          resolveEntry(response);
+        }
+      } else {
+        queuedResponses.push(response);
+      }
+    };
+
+    const deliverQueued = () => {
+      while (pending.length && queuedResponses.length) {
+        const entry = pending.shift();
+        const response = queuedResponses.shift();
+        if (!entry || !response) {
+          continue;
+        }
+        const { resolve: resolveEntry, reject: rejectEntry, expect } = entry;
+        if (expect && !expect.includes(response.code)) {
+          rejectEntry(
+            new Error(
+              `Unexpected SMTP response ${response.code}: ${response.lines.join(' ')}`,
+            ),
+          );
+        } else {
+          resolveEntry(response);
+        }
+      }
+    };
+
+    const processBuffer = () => {
+      while (true) {
+        const index = buffer.indexOf('\r\n');
+        if (index < 0) {
+          break;
+        }
+
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 2);
+        if (!line) {
+          continue;
+        }
+
+        const match = line.match(/^(\d{3})([ -])(.*)$/);
+        if (!match) {
+          continue;
+        }
+
+        const code = Number.parseInt(match[1], 10);
+        const continuation = match[2] === '-';
+        const message = match[3];
+        currentLines.push(message.trim());
+
+        if (!continuation) {
+          processResponse({ code, message, lines: currentLines });
+          currentLines = [];
+        }
+      }
+
+      deliverQueued();
+    };
+
+    const sendCommand = (command, expectCodes) =>
+      new Promise((resolveCommand, rejectCommand) => {
+        if (closed) {
+          rejectCommand(new Error('Connection already closed'));
+          return;
+        }
+
+        const expectArray =
+          typeof expectCodes === 'number'
+            ? [expectCodes]
+            : Array.isArray(expectCodes)
+              ? expectCodes
+              : undefined;
+
+        pending.push({ resolve: resolveCommand, reject: rejectCommand, expect: expectArray });
+
+        if (command !== undefined) {
+          socket.write(`${command}\r\n`);
+        }
+
+        processBuffer();
+      });
+
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      processBuffer();
+    });
+
+    socket.once('error', (error) => {
+      if (!closed) {
+        closed = true;
+        reject(error);
+      }
+      while (pending.length) {
+        pending.shift()?.reject(error);
+      }
+    });
+
+    socket.once('close', () => {
+      closed = true;
+      while (pending.length) {
+        pending.shift()?.reject(new Error('Connection closed'));
+      }
+    });
+
+    const close = () =>
+      new Promise((resolveClose) => {
+        if (closed) {
+          resolveClose();
+          return;
+        }
+
+        socket.once('close', resolveClose);
+        socket.end();
+      });
+
+    socket.once('connect', () => {
+      resolve({ sendCommand, close, socket });
+    });
+  });
+
+const buildMessage = ({ from, to, subject, text, replyTo }) => {
+  const recipients = toArray(to).join(', ');
+  const headers = [
+    `From: ${from}`,
+    `To: ${recipients}`,
+    `Subject: ${subject}`,
+    replyTo ? `Reply-To: ${replyTo}` : null,
+    `Date: ${new Date().toUTCString()}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset=UTF-8',
+    'Content-Transfer-Encoding: 8bit',
+  ].filter(Boolean);
+
+  const normalizedText = escapeLeadingPeriods(normalizeLines(text));
+
+  return `${headers.join('\r\n')}\r\n\r\n${normalizedText}`;
+};
+
+export const createTransport = (options = {}) => {
+  if (options.jsonTransport) {
+    return {
+      // Mimic Nodemailer's sendMail signature by returning a resolved promise.
+      async sendMail(mailOptions) {
+        return {
+          envelope: {
+            from: mailOptions.from,
+            to: toArray(mailOptions.to),
+          },
+          message: JSON.stringify(mailOptions),
+        };
+      },
+    };
+  }
+
+  if (!options.host) {
+    throw new Error('SMTP host is required');
+  }
+
+  return {
+    async sendMail(mailOptions) {
+      const connection = await createSMTPConnection(options);
+
+      try {
+        await connection.sendCommand(undefined, 220);
+        await connection.sendCommand(`EHLO ${options.name ?? 'localhost'}`, 250);
+
+        if (options.auth?.user && options.auth?.pass) {
+          await connection.sendCommand('AUTH LOGIN', 334);
+          await connection.sendCommand(base64(options.auth.user), 334);
+          await connection.sendCommand(base64(options.auth.pass), 235);
+        }
+
+        const fromAddress = mailOptions.from;
+        const recipients = toArray(mailOptions.to);
+
+        await connection.sendCommand(`MAIL FROM:<${fromAddress}>`, 250);
+        for (const recipient of recipients) {
+          await connection.sendCommand(`RCPT TO:<${recipient}>`, 250);
+        }
+
+        await connection.sendCommand('DATA', 354);
+        connection.socket.write(`${buildMessage(mailOptions)}\r\n.\r\n`);
+        await connection.sendCommand(undefined, 250);
+        await connection.sendCommand('QUIT', 221);
+      } finally {
+        await connection.close();
+      }
+    },
+  };
+};
+
+export default { createTransport };

--- a/vendor/nodemailer/package.json
+++ b/vendor/nodemailer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "nodemailer",
+  "version": "0.0.0-local",
+  "type": "module",
+  "main": "./index.js",
+  "exports": "./index.js"
+}


### PR DESCRIPTION
## Summary
- add a ContactService and update the contact component to submit messages with translated status feedback
- implement a /api/contact Express endpoint that validates payloads and forwards mail using a configurable SMTP transport
- vendor a lightweight nodemailer implementation, document required environment variables, and add unit tests for the component and API (including a dedicated server test runner)

## Testing
- npm run test -- --watch=false --progress=false *(fails: Chrome is not available in the environment)*
- npm run test:server


------
https://chatgpt.com/codex/tasks/task_e_68e14b89568c832398c8cf15f60381cc