### PR TITLE
Add dev proxy and combined Angular/Express dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 
 ## Development server
 
-To start a local development server, run:
+The Angular application and the Express API can be started together with:
 
 ```bash
-ng serve
+npm run dev
 ```
 
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
+This command launches the Express server on `http://localhost:4000` (with SSR disabled for faster rebuilds) and the Angular CLI dev server on `http://localhost:4200`. A proxy configuration forwards `/api` requests from the Angular server to the Express instance so the frontend can call the backend without changing URLs. Both processes reload automatically when their source files change.
+
+To run just the Angular application, use `npm start`. To work with the API in isolation, run `npm run serve:api` and send requests to `http://localhost:4000`.
 
 ## Code scaffolding
 
@@ -65,7 +67,19 @@ The `/api/contact` endpoint forwards messages through SMTP using [Nodemailer](ht
 | `CONTACT_FROM_ADDRESS` | No | Explicit “from” address (defaults to the SMTP user or the sender email). |
 | `CONTACT_TRANSPORT` | No | Set to `json` to use Nodemailer's JSON transport (useful for local testing). |
 
-When running tests you can set `CONTACT_TRANSPORT=json` to avoid connecting to a real SMTP server.
+When running tests you can set `CONTACT_TRANSPORT=json` to avoid connecting to a real SMTP server. The development API script (`npm run serve:api`) sets this flag automatically so the `/api/contact` endpoint responds with HTTP 202 during local development.
+
+### Verifying the contact form locally
+
+With the development servers running (`npm run dev`), submit the contact form from the UI or issue a manual request:
+
+```bash
+curl -i -X POST http://localhost:4200/api/contact \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Jane Tester","email":"jane@example.com","message":"This is a message long enough to be accepted."}'
+```
+
+The proxy forwards the request to the Express server which responds with status `202 Accepted` and the JSON payload `{ "message": "Message sent." }` when the payload is valid.
 
 ## Running end-to-end tests
 

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "test:server": "tsc --project tsconfig.server-test.json && node --test .tmp/server-tests/tests/server/contact-endpoint.spec.js",
-    "serve:ssr:portfolio": "node dist/portfolio/server/server.mjs"
+    "serve:ssr:portfolio": "node dist/portfolio/server/server.mjs",
+    "serve:api": "node scripts/serve-api.mjs",
+    "dev": "node scripts/dev.mjs"
   },
   "private": true,
   "dependencies": {

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "http://localhost:4000",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "info"
+  }
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '..');
+
+let shuttingDown = false;
+let exitCode = 0;
+let apiProcess = null;
+let webProcess = null;
+
+function logWithTag(tag, message) {
+  console.log(`[${tag}] ${message}`);
+}
+
+function spawnWithTag(tag, command, args, options = {}) {
+  const child = spawn(command, args, {
+    cwd: projectRoot,
+    stdio: ['inherit', 'pipe', 'pipe'],
+    ...options,
+  });
+
+  const stdoutRl = createInterface({ input: child.stdout });
+  stdoutRl.on('line', (line) => logWithTag(tag, line));
+
+  const stderrRl = createInterface({ input: child.stderr });
+  stderrRl.on('line', (line) => logWithTag(tag, line));
+
+  child.on('exit', (code, signal) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    if (typeof code === 'number' && code !== 0) {
+      exitCode = code;
+    }
+
+    if (signal) {
+      logWithTag(tag, `Process terminated with signal ${signal}`);
+    } else {
+      logWithTag(tag, `Process exited with code ${code}`);
+    }
+
+    shuttingDown = true;
+
+    if (tag === 'api') {
+      if (webProcess && !webProcess.killed) {
+        webProcess.kill('SIGTERM');
+      }
+    } else if (tag === 'web') {
+      if (apiProcess && !apiProcess.killed) {
+        apiProcess.kill('SIGTERM');
+      }
+    }
+  });
+
+  return child;
+}
+
+apiProcess = spawnWithTag('api', process.execPath, [resolve(__dirname, 'serve-api.mjs')]);
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+webProcess = spawnWithTag('web', npmCommand, ['run', 'start']);
+
+const terminate = (signal) => {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  logWithTag('dev', `Received ${signal}. Shutting down...`);
+
+  if (apiProcess && !apiProcess.killed) {
+    apiProcess.kill(signal);
+  }
+
+  if (webProcess && !webProcess.killed) {
+    webProcess.kill(signal);
+  }
+};
+
+process.on('SIGINT', () => terminate('SIGINT'));
+process.on('SIGTERM', () => terminate('SIGTERM'));
+
+process.on('exit', () => {
+  if (!shuttingDown) {
+    shuttingDown = true;
+  }
+
+  if (apiProcess && !apiProcess.killed) {
+    apiProcess.kill('SIGTERM');
+  }
+
+  if (webProcess && !webProcess.killed) {
+    webProcess.kill('SIGTERM');
+  }
+
+  if (exitCode && exitCode !== 0) {
+    process.exitCode = exitCode;
+  }
+});

--- a/scripts/serve-api.mjs
+++ b/scripts/serve-api.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '..');
+
+const tscExecutable = resolve(
+  projectRoot,
+  'node_modules/.bin/tsc' + (process.platform === 'win32' ? '.cmd' : ''),
+);
+const tsconfigPath = resolve(projectRoot, 'tsconfig.server-test.json');
+const runtimeEntry = resolve(__dirname, 'start-compiled-api.mjs');
+const tmpPackageJsonPath = resolve(projectRoot, '.tmp/server-tests/package.json');
+
+let serverProcess = null;
+let shuttingDown = false;
+let pendingRestart = false;
+let initialBuildComplete = false;
+
+function logWithTag(tag, message) {
+  console.log(`[${tag}] ${message}`);
+}
+
+function startServerProcess() {
+  mkdirSync(resolve(projectRoot, '.tmp/server-tests'), { recursive: true });
+  writeFileSync(tmpPackageJsonPath, '{"type":"module"}\n');
+
+  const env = { ...process.env };
+  env['ANGULAR_DISABLE_SSR'] = env['ANGULAR_DISABLE_SSR'] ?? 'true';
+  env['CONTACT_TRANSPORT'] = env['CONTACT_TRANSPORT'] ?? 'json';
+  env['PORT'] = env['PORT'] ?? '4000';
+
+  logWithTag('api', 'Starting Express server on http://localhost:' + env['PORT']);
+
+  serverProcess = spawn(process.execPath, [runtimeEntry], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+    env,
+  });
+
+  serverProcess.on('exit', (code, signal) => {
+    const wasRestarting = pendingRestart;
+    serverProcess = null;
+    pendingRestart = false;
+
+    if (shuttingDown) {
+      return;
+    }
+
+    if (signal) {
+      logWithTag('api', `Server process terminated by ${signal}`);
+    } else if (typeof code === 'number' && code !== 0) {
+      logWithTag('api', `Server process exited with code ${code}`);
+    }
+
+    if (wasRestarting) {
+      startServerProcess();
+    }
+  });
+}
+
+function requestServerRestart() {
+  if (!initialBuildComplete) {
+    return;
+  }
+
+  if (!serverProcess) {
+    startServerProcess();
+    return;
+  }
+
+  pendingRestart = true;
+  serverProcess.kill('SIGTERM');
+}
+
+const tscProcess = spawn(
+  tscExecutable,
+  ['--project', tsconfigPath, '--watch', '--preserveWatchOutput'],
+  {
+    cwd: projectRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  },
+);
+
+tscProcess.on('exit', (code, signal) => {
+  if (shuttingDown) {
+    return;
+  }
+
+  if (signal) {
+    logWithTag('tsc', `TypeScript compiler terminated by ${signal}`);
+  } else {
+    logWithTag('tsc', `TypeScript compiler exited with code ${code}`);
+  }
+
+  shuttingDown = true;
+  if (serverProcess && !serverProcess.killed) {
+    serverProcess.kill('SIGTERM');
+  }
+});
+
+const forwardOutput = (stream, tag) => {
+  const rl = createInterface({ input: stream });
+  rl.on('line', (line) => {
+    logWithTag(tag, line);
+
+    if (line.includes('Found 0 errors.')) {
+      initialBuildComplete = true;
+      requestServerRestart();
+    }
+  });
+};
+
+forwardOutput(tscProcess.stdout, 'tsc');
+forwardOutput(tscProcess.stderr, 'tsc');
+
+const terminate = (signal) => {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  logWithTag('dev', `Received ${signal}. Shutting down...`);
+
+  if (serverProcess && !serverProcess.killed) {
+    serverProcess.kill(signal);
+  }
+
+  tscProcess.kill(signal);
+};
+
+process.on('SIGINT', () => terminate('SIGINT'));
+process.on('SIGTERM', () => terminate('SIGTERM'));
+
+process.on('exit', () => {
+  shuttingDown = true;
+  if (serverProcess && !serverProcess.killed) {
+    serverProcess.kill('SIGTERM');
+  }
+  if (!tscProcess.killed) {
+    tscProcess.kill('SIGTERM');
+  }
+});

--- a/scripts/start-compiled-api.mjs
+++ b/scripts/start-compiled-api.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '..');
+const compiledEntry = resolve(projectRoot, '.tmp/server-tests/src/server.js');
+
+const moduleUrl = pathToFileURL(compiledEntry).href + `?cache-bust=${Date.now()}`;
+
+const { app } = await import(moduleUrl);
+
+if (!app || typeof app.listen !== 'function') {
+  console.error('The compiled server module does not export an Express application.');
+  process.exit(1);
+}
+
+const port = Number.parseInt(process.env['PORT'] ?? '4000', 10);
+
+const server = app.listen(port, '0.0.0.0', () => {
+  console.log(`Express API listening on http://localhost:${port}`);
+});
+
+const shutdown = (signal) => {
+  server.close(() => {
+    process.exit(0);
+  });
+};
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));


### PR DESCRIPTION
## Summary
- add a proxy configuration so `ng serve` forwards `/api` requests to the Express server running on port 4000
- create Node-based helper scripts to run the API alone or alongside the Angular dev server without extra dependencies
- update the README with the new development workflow and local contact form verification steps

## Testing
- npm run test:server

------
https://chatgpt.com/codex/tasks/task_e_68e19f7998e883239309f07114d011c5