### PR TITLE
fix: export API handler via CommonJS

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
-export type ExpressHandler = (req: IncomingMessage, res: ServerResponse) => void;
+type ExpressHandler = (req: IncomingMessage, res: ServerResponse) => void;
 
 let cachedHandler: ExpressHandler | null = null;
 
@@ -18,11 +18,13 @@ const loadHandler = async (): Promise<ExpressHandler> => {
   return cachedHandler;
 };
 
-export default async function handler(
+const handler = async (
   req: IncomingMessage,
   res: ServerResponse,
-): Promise<void> {
+): Promise<void> => {
   const app = await loadHandler();
 
-  return app(req, res);
-}
+  await app(req, res);
+};
+
+module.exports = handler;


### PR DESCRIPTION
## Summary
- update the API entrypoint to expose the handler via CommonJS exports
- retain lazy loading of the built server bundle and express app bootstrap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1aff05ea88323aea6bbec811277ef