### PR TITLE
Fix serve-api to spawn TypeScript via Node

### DIFF
--- a/scripts/serve-api.mjs
+++ b/scripts/serve-api.mjs
@@ -9,10 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = resolve(__dirname, '..');
 
-const tscExecutable = resolve(
-  projectRoot,
-  'node_modules/.bin/tsc' + (process.platform === 'win32' ? '.cmd' : ''),
-);
+const tscJsPath = resolve(projectRoot, 'node_modules/typescript/lib/tsc.js');
 const tsconfigPath = resolve(projectRoot, 'tsconfig.server-test.json');
 const runtimeEntry = resolve(__dirname, 'start-compiled-api.mjs');
 const tmpPackageJsonPath = resolve(projectRoot, '.tmp/server-tests/package.json');
@@ -79,8 +76,8 @@ function requestServerRestart() {
 }
 
 const tscProcess = spawn(
-  tscExecutable,
-  ['--project', tsconfigPath, '--watch', '--preserveWatchOutput'],
+  process.execPath,
+  [tscJsPath, '--project', tsconfigPath, '--watch', '--preserveWatchOutput'],
   {
     cwd: projectRoot,
     stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- resolve the TypeScript compiler entry point directly and spawn it with Node
- keep existing watch arguments so serve:api runs the same across platforms

## Testing
- npm run serve:api

------
https://chatgpt.com/codex/tasks/task_e_68e24616ccd883239d18b49401dc5b2c