### PR TITLE
Remove redundant contact API rewrite from Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,1 @@
-{
-  "rewrites": [
-    {
-      "source": "/api/contact",
-      "destination": "/api"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
## Summary
- remove the Vercel rewrite that redirected `/api/contact` to `/api` so the platform can reach `api/contact.cjs` directly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e250e1dc20832381b33f9b77def441