### PR TITLE
feat: secure admin panel and persist messages

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,11 +3,14 @@ import { HomeComponent } from './components/home/home.component';
 import { AboutComponent } from './components/about/about.component';
 import { ContactComponent } from './components/contact/contact.component';
 import { AdminComponent } from './components/admin/admin.component';
+import { AdminLoginComponent } from './components/admin-login/admin-login.component';
+import { adminGuard } from './guards/admin.guard';
 
 export const routes: Routes = [
   { path: '', redirectTo: '/portfolio', pathMatch: 'full' },
   { path: 'portfolio', component: HomeComponent },
   { path: 'about', component: AboutComponent },
   { path: 'contact', component: ContactComponent },
-  { path: 'admin', component: AdminComponent },
+  { path: 'admin/login', component: AdminLoginComponent },
+  { path: 'admin', component: AdminComponent, canActivate: [adminGuard] },
 ];

--- a/src/app/components/admin-login/admin-login.component.css
+++ b/src/app/components/admin-login/admin-login.component.css
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+  padding: 4rem 1.5rem;
+}
+
+form.ng-invalid.ng-touched input {
+  border-color: rgba(244, 63, 94, 0.7);
+}

--- a/src/app/components/admin-login/admin-login.component.html
+++ b/src/app/components/admin-login/admin-login.component.html
@@ -1,0 +1,89 @@
+<section
+  class="relative isolate flex min-h-[60vh] items-center justify-center overflow-hidden rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white via-white to-slate-50 px-6 py-16 shadow-xl shadow-slate-900/5 backdrop-blur dark:border-slate-800/60 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900"
+  aria-labelledby="admin-login-title"
+>
+  <div class="pointer-events-none absolute -top-32 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-blue-500/10 blur-3xl"></div>
+  <div class="pointer-events-none absolute -bottom-24 right-16 h-72 w-72 rounded-full bg-purple-500/10 blur-3xl"></div>
+
+  <div class="relative z-10 w-full max-w-md space-y-8">
+    <header class="space-y-3 text-center">
+      <p class="text-sm font-semibold uppercase tracking-[0.45em] text-blue-500">
+        {{ 'ADMIN_LOGIN.PRETITLE' | translate }}
+      </p>
+      <h1 id="admin-login-title" class="text-3xl font-extrabold text-slate-900 dark:text-white">
+        {{ 'ADMIN_LOGIN.TITLE' | translate }}
+      </h1>
+      <p class="text-base leading-relaxed text-slate-600 dark:text-slate-300">
+        {{ 'ADMIN_LOGIN.DESCRIPTION' | translate }}
+      </p>
+    </header>
+
+    <form
+      class="space-y-6 rounded-3xl border border-slate-200/70 bg-white/90 p-8 shadow-lg dark:border-slate-800/60 dark:bg-slate-900/70"
+      [formGroup]="loginForm"
+      (ngSubmit)="onSubmit()"
+      novalidate
+    >
+      <div class="space-y-2">
+        <label class="block text-sm font-medium text-slate-700 dark:text-slate-300" for="username">
+          {{ 'ADMIN_LOGIN.USERNAME.LABEL' | translate }}
+        </label>
+        <input
+          id="username"
+          type="text"
+          formControlName="username"
+          class="w-full rounded-xl border border-slate-300/70 bg-white/80 px-4 py-3 text-base text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-4 focus:ring-blue-500/20 dark:border-slate-700/60 dark:bg-slate-900/80 dark:text-white"
+          [attr.aria-invalid]="usernameControl?.invalid && usernameControl?.touched"
+          autocomplete="username"
+        />
+        <p
+          *ngIf="usernameControl?.invalid && usernameControl?.touched"
+          class="text-sm text-rose-500"
+        >
+          {{ 'ADMIN_LOGIN.USERNAME.ERROR' | translate }}
+        </p>
+      </div>
+
+      <div class="space-y-2">
+        <label class="block text-sm font-medium text-slate-700 dark:text-slate-300" for="password">
+          {{ 'ADMIN_LOGIN.PASSWORD.LABEL' | translate }}
+        </label>
+        <input
+          id="password"
+          type="password"
+          formControlName="password"
+          class="w-full rounded-xl border border-slate-300/70 bg-white/80 px-4 py-3 text-base text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-4 focus:ring-blue-500/20 dark:border-slate-700/60 dark:bg-slate-900/80 dark:text-white"
+          [attr.aria-invalid]="passwordControl?.invalid && passwordControl?.touched"
+          autocomplete="current-password"
+        />
+        <p
+          *ngIf="passwordControl?.invalid && passwordControl?.touched"
+          class="text-sm text-rose-500"
+        >
+          {{ 'ADMIN_LOGIN.PASSWORD.ERROR' | translate }}
+        </p>
+      </div>
+
+      <p *ngIf="error" class="rounded-xl bg-rose-500/10 px-4 py-3 text-sm text-rose-600 dark:text-rose-400">
+        {{ 'ADMIN_LOGIN.ERROR' | translate }}
+      </p>
+
+      <button
+        type="submit"
+        class="w-full rounded-xl bg-gradient-to-r from-blue-600 via-indigo-500 to-purple-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-blue-500/30 disabled:cursor-not-allowed disabled:opacity-70"
+        [disabled]="submitting"
+      >
+        <span *ngIf="!submitting; else loading">{{ 'ADMIN_LOGIN.SUBMIT' | translate }}</span>
+        <ng-template #loading>
+          <span class="flex items-center justify-center gap-2">
+            <svg class="h-5 w-5 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor"></circle>
+              <path class="opacity-75" d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-linecap="round"></path>
+            </svg>
+            {{ 'ADMIN_LOGIN.SUBMITTING' | translate }}
+          </span>
+        </ng-template>
+      </button>
+    </form>
+  </div>
+</section>

--- a/src/app/components/admin-login/admin-login.component.ts
+++ b/src/app/components/admin-login/admin-login.component.ts
@@ -1,0 +1,57 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-admin-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, TranslateModule],
+  templateUrl: './admin-login.component.html',
+  styleUrls: ['./admin-login.component.css'],
+})
+export class AdminLoginComponent {
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  readonly loginForm = this.formBuilder.nonNullable.group({
+    username: ['', [Validators.required]],
+    password: ['', [Validators.required]],
+  });
+
+  error = false;
+  submitting = false;
+
+  onSubmit(): void {
+    if (this.submitting || this.loginForm.invalid) {
+      this.loginForm.markAllAsTouched();
+      return;
+    }
+
+    this.error = false;
+    this.submitting = true;
+
+    const { username, password } = this.loginForm.getRawValue();
+    const authenticated = this.authService.login(username, password);
+
+    this.submitting = false;
+
+    if (authenticated) {
+      this.router.navigate(['/admin']);
+      return;
+    }
+
+    this.error = true;
+  }
+
+  get usernameControl() {
+    return this.loginForm.get('username');
+  }
+
+  get passwordControl() {
+    return this.loginForm.get('password');
+  }
+}

--- a/src/app/components/admin/admin.component.html
+++ b/src/app/components/admin/admin.component.html
@@ -10,16 +10,30 @@
   ></div>
 
   <div class="relative mx-auto max-w-5xl space-y-12">
-    <header class="space-y-4 text-center">
-      <p class="text-sm font-semibold uppercase tracking-[0.45em] text-blue-500">
-        {{ 'ADMIN.PRETITLE' | translate }}
-      </p>
-      <h1 id="admin-title" class="text-3xl font-extrabold text-slate-900 dark:text-white">
-        {{ 'ADMIN.TITLE' | translate }}
-      </h1>
-      <p class="text-base leading-relaxed text-slate-600 dark:text-slate-300">
-        {{ 'ADMIN.DESCRIPTION' | translate }}
-      </p>
+    <header class="flex flex-col items-center gap-4 text-center md:flex-row md:items-start md:justify-between md:text-left">
+      <div class="space-y-4">
+        <p class="text-sm font-semibold uppercase tracking-[0.45em] text-blue-500">
+          {{ 'ADMIN.PRETITLE' | translate }}
+        </p>
+        <h1 id="admin-title" class="text-3xl font-extrabold text-slate-900 dark:text-white">
+          {{ 'ADMIN.TITLE' | translate }}
+        </h1>
+        <p class="text-base leading-relaxed text-slate-600 dark:text-slate-300">
+          {{ 'ADMIN.DESCRIPTION' | translate }}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        class="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300/80 bg-white/80 px-5 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-transparent hover:bg-slate-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-blue-500/20 dark:border-slate-700/70 dark:bg-slate-900/80 dark:text-slate-200 dark:hover:bg-slate-800"
+        (click)="logout()"
+      >
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6A2.25 2.25 0 0 0 5.25 5.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9l3-3m0 0 3 3m-3-3v12" />
+        </svg>
+        {{ 'ADMIN.LOGOUT' | translate }}
+      </button>
     </header>
 
     <ng-container *ngIf="messages$ | async as messages">

--- a/src/app/components/admin/admin.component.spec.ts
+++ b/src/app/components/admin/admin.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { AdminComponent } from './admin.component';
 import { ContactMessagesService } from '../../services/contact-messages.service';
@@ -11,7 +12,7 @@ describe('AdminComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AdminComponent],
+      imports: [AdminComponent, RouterTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminComponent);

--- a/src/app/components/admin/admin.component.ts
+++ b/src/app/components/admin/admin.component.ts
@@ -6,6 +6,7 @@ import {
   ContactMessage,
   ContactMessagesService,
 } from '../../services/contact-messages.service';
+import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-admin',
@@ -16,9 +17,14 @@ import {
 })
 export class AdminComponent {
   private readonly contactMessagesService = inject(ContactMessagesService);
+  private readonly authService = inject(AuthService);
   readonly messages$ = this.contactMessagesService.messages$;
 
   trackByMessage(_: number, message: ContactMessage): number {
     return message.id;
+  }
+
+  logout(): void {
+    this.authService.logout();
   }
 }

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,0 +1,10 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const adminGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  return authService.isAdmin() || router.parseUrl('/admin/login');
+};

--- a/src/app/i18n/feature-translations.ts
+++ b/src/app/i18n/feature-translations.ts
@@ -235,6 +235,23 @@ export const featureTranslationsEn = {
     MESSAGE: {
       RECEIVED_AT: 'Received',
     },
+    LOGOUT: 'Log out',
+  },
+  ADMIN_LOGIN: {
+    PRETITLE: 'Restricted area',
+    TITLE: 'Admin sign in',
+    DESCRIPTION: 'Enter your administrator credentials to access incoming contact messages.',
+    USERNAME: {
+      LABEL: 'Username',
+      ERROR: 'Username is required.',
+    },
+    PASSWORD: {
+      LABEL: 'Password',
+      ERROR: 'Password is required.',
+    },
+    SUBMIT: 'Sign in',
+    SUBMITTING: 'Signing in...',
+    ERROR: 'Incorrect credentials. Please try again.',
   },
 } as const;
 
@@ -474,5 +491,22 @@ export const featureTranslationsSr = {
     MESSAGE: {
       RECEIVED_AT: 'Primljeno',
     },
+    LOGOUT: 'Odjavi se',
+  },
+  ADMIN_LOGIN: {
+    PRETITLE: 'Ograničen pristup',
+    TITLE: 'Prijava za admina',
+    DESCRIPTION: 'Unesite administratorske podatke kako biste pristupili pristiglim porukama.',
+    USERNAME: {
+      LABEL: 'Korisničko ime',
+      ERROR: 'Korisničko ime je obavezno.',
+    },
+    PASSWORD: {
+      LABEL: 'Lozinka',
+      ERROR: 'Lozinka je obavezna.',
+    },
+    SUBMIT: 'Prijavi se',
+    SUBMITTING: 'Prijavljivanje...',
+    ERROR: 'Pogrešni podaci. Pokušajte ponovo.',
   },
 } as const;

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,68 @@
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Router } from '@angular/router';
+
+const ADMIN_STORAGE_KEY = 'myportfolio.admin.isAuthenticated';
+const ADMIN_USERNAME = 'admin';
+const ADMIN_PASSWORD = 'admin123';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly router = inject(Router);
+  private readonly isAdminSubject = new BehaviorSubject<boolean>(
+    this.restoreSession(),
+  );
+
+  get isAdmin$(): Observable<boolean> {
+    return this.isAdminSubject.asObservable();
+  }
+
+  isAdmin(): boolean {
+    return this.isAdminSubject.value;
+  }
+
+  login(username: string, password: string): boolean {
+    if (username.trim() === ADMIN_USERNAME && password === ADMIN_PASSWORD) {
+      this.isAdminSubject.next(true);
+      this.persistSession(true);
+      return true;
+    }
+
+    return false;
+  }
+
+  logout(): void {
+    this.isAdminSubject.next(false);
+    this.persistSession(false);
+    this.router.navigate(['/admin/login']);
+  }
+
+  private restoreSession(): boolean {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(ADMIN_STORAGE_KEY);
+      return stored === 'true';
+    } catch (error) {
+      console.error('Failed to read admin session from storage', error);
+      return false;
+    }
+  }
+
+  private persistSession(isAuthenticated: boolean): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(
+        ADMIN_STORAGE_KEY,
+        isAuthenticated ? 'true' : 'false',
+      );
+    } catch (error) {
+      console.error('Failed to persist admin session', error);
+    }
+  }
+}

--- a/src/app/services/contact-messages.service.ts
+++ b/src/app/services/contact-messages.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
+const STORAGE_KEY = 'myportfolio.contact.messages';
+
 export type ContactMessage = {
   readonly id: number;
   readonly name: string;
@@ -20,6 +22,17 @@ export class ContactMessagesService {
   private readonly messagesSubject = new BehaviorSubject<ContactMessage[]>([]);
   private nextId = 1;
 
+  constructor() {
+    const storedMessages = this.restoreMessages();
+    if (storedMessages.length) {
+      this.messagesSubject.next(storedMessages);
+      this.nextId = storedMessages.reduce(
+        (highestId, message) => Math.max(highestId, message.id),
+        0,
+      ) + 1;
+    }
+  }
+
   get messages$(): Observable<ContactMessage[]> {
     return this.messagesSubject.asObservable();
   }
@@ -34,6 +47,50 @@ export class ContactMessagesService {
     };
 
     const currentMessages = this.messagesSubject.value;
-    this.messagesSubject.next([message, ...currentMessages]);
+    const updatedMessages = [message, ...currentMessages];
+    this.messagesSubject.next(updatedMessages);
+    this.persistMessages(updatedMessages);
+  }
+
+  private restoreMessages(): ContactMessage[] {
+    if (typeof window === 'undefined') {
+      return [];
+    }
+
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return [];
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed.map((item: ContactMessage) => ({
+        ...item,
+        createdAt: new Date(item.createdAt),
+      }));
+    } catch (error) {
+      console.error('Failed to restore contact messages from storage', error);
+      return [];
+    }
+  }
+
+  private persistMessages(messages: ContactMessage[]): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const serializable = messages.map((message) => ({
+        ...message,
+        createdAt: message.createdAt.toISOString(),
+      }));
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(serializable));
+    } catch (error) {
+      console.error('Failed to persist contact messages', error);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated admin login screen and guard to protect the admin inbox
- persist contact messages in local storage so submissions survive reloads
- enhance admin UI with logout action and localized copy updates

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless --progress=false *(fails: ChromeHeadless binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ba96658483238dc2692a01686fff